### PR TITLE
Add CLI flag to show Polygon API data

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ poetry run python src/main.py --ticker AAPL,MSFT,NVDA --show-reasoning
 run.bat --ticker AAPL,MSFT,NVDA --show-reasoning main
 ```
 
+You can specify a `--show-polygon-data` flag to print the requests made to Polygon and the data returned. This is helpful for debugging API queries.
+
+```bash
+# With Poetry:
+poetry run python src/main.py --ticker AAPL,MSFT,NVDA --show-polygon-data
+
+# With Docker (on Linux/Mac):
+./run.sh --ticker AAPL,MSFT,NVDA --show-polygon-data main
+
+# With Docker (on Windows):
+run.bat --ticker AAPL,MSFT,NVDA --show-polygon-data main
+```
+
 You can optionally specify the start and end dates to make decisions for a specific time period.
 
 ```bash

--- a/run.bat
+++ b/run.bat
@@ -9,6 +9,7 @@ set END_DATE=
 set INITIAL_AMOUNT=100000.0
 set MARGIN_REQUIREMENT=0.0
 set SHOW_REASONING=
+set SHOW_POLYGON_DATA=
 set COMMAND=
 set MODEL_NAME=
 
@@ -26,6 +27,7 @@ echo   --initial-cash AMT  Initial cash position (default: 100000.0)
 echo   --margin-requirement RATIO  Margin requirement ratio (default: 0.0)
 echo   --ollama            Use Ollama for local LLM inference
 echo   --show-reasoning    Show reasoning from each agent
+echo   --show-polygon-data Print Polygon queries and responses
 echo.
 echo Commands:
 echo   main                Run the main hedge fund application
@@ -86,6 +88,11 @@ if "%~1"=="--ollama" (
 )
 if "%~1"=="--show-reasoning" (
     set SHOW_REASONING=--show-reasoning
+    shift
+    goto :parse_args
+)
+if "%~1"=="--show-polygon-data" (
+    set SHOW_POLYGON_DATA=--show-polygon-data
     shift
     goto :parse_args
 )
@@ -326,12 +333,12 @@ if not "!USE_OLLAMA!"=="" (
     :: Use the appropriate service based on command and reasoning flag
     if "!COMMAND!"=="main" (
         if not "!SHOW_REASONING!"=="" (
-            !COMPOSE_CMD! run --rm hedge-fund-reasoning python src/main.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! --ollama
+            !COMPOSE_CMD! run --rm hedge-fund-reasoning python src/main.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! !SHOW_POLYGON_DATA! --ollama
         ) else (
-            !COMPOSE_CMD! run --rm hedge-fund-ollama python src/main.py --ticker !TICKER! !COMMAND_OVERRIDE! --ollama
+            !COMPOSE_CMD! run --rm hedge-fund-ollama python src/main.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_POLYGON_DATA! --ollama
         )
     ) else if "!COMMAND!"=="backtest" (
-        !COMPOSE_CMD! run --rm backtester-ollama python src/backtester.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! --ollama
+        !COMPOSE_CMD! run --rm backtester-ollama python src/backtester.py --ticker !TICKER! !COMMAND_OVERRIDE! !SHOW_REASONING! !SHOW_POLYGON_DATA! --ollama
     )
     
     exit /b 0
@@ -343,6 +350,7 @@ set CMD=docker run -it --rm -v %cd%\.env:/app/.env
 
 :: Add the command
 set CMD=!CMD! ai-hedge-fund python !SCRIPT_PATH! --ticker !TICKER! !START_DATE! !END_DATE! !INITIAL_PARAM! --margin-requirement !MARGIN_REQUIREMENT! !SHOW_REASONING!
+set CMD=!CMD! !SHOW_POLYGON_DATA!
 
 :: Run the command
 echo Running: !CMD!

--- a/run.sh
+++ b/run.sh
@@ -14,6 +14,7 @@ show_help() {
   echo "  --margin-requirement RATIO  Margin requirement ratio (default: 0.0)"
   echo "  --ollama            Use Ollama for local LLM inference"
   echo "  --show-reasoning    Show reasoning from each agent"
+  echo "  --show-polygon-data Print Polygon queries and responses"
   echo ""
   echo "Commands:"
   echo "  main                Run the main hedge fund application"
@@ -42,6 +43,7 @@ END_DATE=""
 INITIAL_AMOUNT="100000.0"
 MARGIN_REQUIREMENT="0.0"
 SHOW_REASONING=""
+SHOW_POLYGON_DATA=""
 COMMAND=""
 MODEL_NAME=""
 
@@ -74,6 +76,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --show-reasoning)
       SHOW_REASONING="--show-reasoning"
+      shift
+      ;;
+    --show-polygon-data)
+      SHOW_POLYGON_DATA="--show-polygon-data"
       shift
       ;;
     main|backtest|build|help|compose|ollama)
@@ -288,19 +294,19 @@ if [ -n "$USE_OLLAMA" ]; then
   if [ -n "$MARGIN_REQUIREMENT" ]; then
     COMMAND_OVERRIDE="$COMMAND_OVERRIDE --margin-requirement $MARGIN_REQUIREMENT"
   fi
-  
+
   # Run the command with Docker Compose
   echo "Running AI Hedge Fund with Ollama using Docker Compose..."
   
   # Use the appropriate service based on command and reasoning flag
   if [ "$COMMAND" = "main" ]; then
     if [ -n "$SHOW_REASONING" ]; then
-      $COMPOSE_CMD $GPU_CONFIG run --rm hedge-fund-reasoning python src/main.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING --ollama
+      $COMPOSE_CMD $GPU_CONFIG run --rm hedge-fund-reasoning python src/main.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING $SHOW_POLYGON_DATA --ollama
     else
-      $COMPOSE_CMD $GPU_CONFIG run --rm hedge-fund-ollama python src/main.py --ticker $TICKER $COMMAND_OVERRIDE --ollama
+      $COMPOSE_CMD $GPU_CONFIG run --rm hedge-fund-ollama python src/main.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_POLYGON_DATA --ollama
     fi
   elif [ "$COMMAND" = "backtest" ]; then
-    $COMPOSE_CMD $GPU_CONFIG run --rm backtester-ollama python src/backtester.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING --ollama
+    $COMPOSE_CMD $GPU_CONFIG run --rm backtester-ollama python src/backtester.py --ticker $TICKER $COMMAND_OVERRIDE $SHOW_REASONING $SHOW_POLYGON_DATA --ollama
   fi
   
   exit 0
@@ -312,6 +318,7 @@ CMD="docker run -it --rm -v $(pwd)/.env:/app/.env"
 
 # Add the command
 CMD="$CMD ai-hedge-fund python $SCRIPT_PATH --ticker $TICKER $START_DATE $END_DATE $INITIAL_PARAM --margin-requirement $MARGIN_REQUIREMENT $SHOW_REASONING"
+CMD="$CMD $SHOW_POLYGON_DATA"
 
 # Run the command
 echo "Running: $CMD"

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,5 @@
 import sys
+import os
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage
@@ -145,9 +146,17 @@ if __name__ == "__main__":
     parser.add_argument("--end-date", type=str, help="End date (YYYY-MM-DD). Defaults to today")
     parser.add_argument("--show-reasoning", action="store_true", help="Show reasoning from each agent")
     parser.add_argument("--show-agent-graph", action="store_true", help="Show the agent graph")
+    parser.add_argument(
+        "--show-polygon-data",
+        action="store_true",
+        help="Print Polygon queries and responses",
+    )
     parser.add_argument("--ollama", action="store_true", help="Use Ollama for local LLM inference")
 
     args = parser.parse_args()
+
+    if args.show_polygon_data:
+        os.environ["SHOW_POLYGON_DATA"] = "1"
 
     # Parse tickers from comma-separated string
     tickers = [ticker.strip() for ticker in args.tickers.split(",")]

--- a/src/tools/api.py
+++ b/src/tools/api.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import os
 import pandas as pd
 import requests
@@ -22,10 +23,15 @@ def _polygon_get(url: str, params: dict | None = None) -> dict:
         params = {}
     if api_key := os.environ.get("POLYGON_API_KEY"):
         params["apiKey"] = api_key
+    if os.environ.get("SHOW_POLYGON_DATA") == "1":
+        print(f"Querying Polygon: {url} params={params}")
     response = requests.get(url, params=params)
     if response.status_code != 200:
         raise Exception(f"Error fetching data: {response.status_code} - {response.text}")
-    return response.json()
+    data = response.json()
+    if os.environ.get("SHOW_POLYGON_DATA") == "1":
+        print(f"Polygon response: {json.dumps(data, indent=2)}")
+    return data
 
 
 def _to_numeric(value):


### PR DESCRIPTION
## Summary
- print Polygon API requests and responses when `SHOW_POLYGON_DATA` is set
- add `--show-polygon-data` option to `src/main.py`
- document the new flag in `README.md`
- expose flag through `run.sh` and `run.bat`

## Testing
- `python -m py_compile src/tools/api.py src/main.py`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*