### PR TITLE
Handle JSON parse failures

### DIFF
--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -53,8 +53,9 @@ def call_llm(
             # For non-JSON support models, we need to extract and parse the JSON manually
             if model_info and not model_info.has_json_mode():
                 parsed_result = extract_json_from_response(result.content)
-                if parsed_result:
-                    return pydantic_model(**parsed_result)
+                if parsed_result is None:
+                    raise ValueError("Failed to parse JSON from LLM response")
+                return pydantic_model(**parsed_result)
             else:
                 return result
 


### PR DESCRIPTION
## Summary
- raise an error when the LLM response JSON can't be parsed
- return the caller's default object on failure so agents fall back to neutral signals

## Testing
- `pytest -q` *(fails: command not found)*